### PR TITLE
[glibc] Disable crypt. Contributes to JB#54931

### DIFF
--- a/glibc.changes
+++ b/glibc.changes
@@ -1,3 +1,6 @@
+* Mon Sep 27 2021 Björn Bidar <bjorn.bidar@jolla.com> - 2.30+git9
+- Disable crypt. Contributes to JB#54931
+
 * Tue Aug 31 2021 Björn Bidar <bjorn.bidar@jolla.com> - 2.30+git8
 - Document all patches and use %autosetup
 - Add fix for CVE-2021-38604. Fixes JB#55185

--- a/glibc.spec
+++ b/glibc.spec
@@ -5,7 +5,7 @@
 Name: glibc
 
 Summary: GNU C library shared libraries
-Version: 2.30+git8
+Version: 2.30+git9
 Release: 0
 License: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+
 URL: http://www.gnu.org/software/libc/
@@ -290,7 +290,8 @@ build()
 %if %{with bootstrap}
 		--without-selinux \
 %endif
-                ||
+                --disable-crypt    \
+              ||
 		{ cat config.log; false; }
 
 	make %{?_smp_mflags} -O -r CFLAGS="$build_CFLAGS"


### PR DESCRIPTION
We disable the builtin libcrypt as it's replaced by libxcrypt.