### PR TITLE
[glibc] Fix update order regarding libgcc. JB#63419

### DIFF
--- a/glibc.changes
+++ b/glibc.changes
@@ -1,3 +1,6 @@
+* Thu Jul 10 2025 Pami Ketolainen <pami.ketolainen@jolla.com> - 2.41+git2
+- Fix update order regarding libgcc. JB#63419
+
 * Sat Apr 12 2025 Matti Lehtimäki <matti.lehtimaki@jolla.com> - 2.41+git1
 - Update to version 2.41. Fixes JB#49501
 

--- a/glibc.spec
+++ b/glibc.spec
@@ -5,7 +5,7 @@
 Name: glibc
 
 Summary: GNU C library shared libraries
-Version: 2.41+git1
+Version: 2.41+git2
 Release: 0
 License: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+
 URL: http://www.gnu.org/software/libc/
@@ -34,8 +34,6 @@ Provides: ld-linux.so.3(GLIBC_2.4)
 %endif
 
 BuildRequires: xz tar
-# Require libgcc in case some program calls pthread_cancel in its %%post
-Requires(pre): libgcc
 BuildRequires:  zlib-devel texinfo
 BuildRequires: sed >= 3.95, libcap-devel, gettext
 BuildRequires: gawk,  util-linux


### PR DESCRIPTION
Installing libgcc built agains new glibc before new glibc breaks at least on 32bit arm due to some unwind related symbol dependencies.

The Requires(pre) libgcc dates back to the initail import of Fedora spec and could not trace back to it's original reasoning, but it has since been removed also from Fedora spec.