### PR TITLE
[glibc] Add libxcrypt in devel dependencies. JB#63702

### DIFF
--- a/glibc.changes
+++ b/glibc.changes
@@ -1,3 +1,6 @@
+* Mon Oct 6 2025 Pami Ketolainen <pami.ketolainen@jolla.com> - 2.41+git4
+- Add libxcrypt in devel dependencies. JB#63702
+
 * Thu Sep 25 2025 Matti Lehtimäki <matti.lehtimaki@jolla.com> - 2.41+git3
 - Backport patch to fix a double-free issue. JB#63622
 

--- a/glibc.spec
+++ b/glibc.spec
@@ -5,7 +5,7 @@
 Name: glibc
 
 Summary: GNU C library shared libraries
-Version: 2.41+git3
+Version: 2.41+git4
 Release: 0
 License: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+
 URL: http://www.gnu.org/software/libc/
@@ -91,6 +91,7 @@ Requires(pre): /sbin/install-info
 Requires(pre): %{name}-headers
 Requires: %{name}-headers = %{version}-%{release}
 Requires: %{name} = %{version}-%{release}
+Requires: libxcrypt-devel
 
 %description devel
 The glibc-devel package contains the object files necessary


### PR DESCRIPTION
Some things (openssh in this case) may silently fall back to using the basic DES only crypt() implementation, and that causes unexpected behavior.