### PR TITLE
Don't use hardcoded find-debuginfo path. JB#62519

### DIFF
--- a/glibc.changes
+++ b/glibc.changes
@@ -1,3 +1,6 @@
+* Mon Oct 9 2025 Matti Viljanen <matti.viljanen@jolla.com> - 2.41+git5
+- Don't use hardcoded find-debuginfo path. JB#62519
+
 * Mon Oct 6 2025 Pami Ketolainen <pami.ketolainen@jolla.com> - 2.41+git4
 - Add libxcrypt in devel dependencies. JB#63702
 

--- a/glibc.spec
+++ b/glibc.spec
@@ -5,7 +5,7 @@
 Name: glibc
 
 Summary: GNU C library shared libraries
-Version: 2.41+git4
+Version: 2.41+git5
 Release: 0
 License: LGPLv2+ and LGPLv2+ with exceptions and GPLv2+
 URL: http://www.gnu.org/software/libc/
@@ -218,7 +218,7 @@ build_CFLAGS="$BuildFlags -O3"
 OPT_FLAGS=`echo "$RPM_OPT_FLAGS" | sed -e "s/-O2\ //g" \
                    | sed -e "s/-fstack-protector\ //g" \
                    | sed -e "s/-Wp,-D_FORTIFY_SOURCE=2\ //g" \
-                   | sed -e "s/--param=ssp-buffer-size=4\ //g"` 
+                   | sed -e "s/--param=ssp-buffer-size=4\ //g"`
 
 build_CFLAGS="$build_CFLAGS $OPT_FLAGS"
 %endif
@@ -810,7 +810,7 @@ find_debuginfo_args="$find_debuginfo_args \
 	"
 %endif
 
-/usr/lib/rpm/find-debuginfo.sh $find_debuginfo_args -o debuginfo.filelist
+find-debuginfo $find_debuginfo_args -o debuginfo.filelist
 
 # List all of the *.a archives in the debug directory.
 list_debug_archives()


### PR DESCRIPTION
Since debugedit package was added, find-debuginfo is in path and we can just use it.